### PR TITLE
Support one-time flow identifiers in flow execution

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -38,6 +38,8 @@ public class Constants {
     public static final String REQUIRED = "required";
     public static final String ERROR = "error";
     public static final String WEBAUTHN_DATA = "webAuthnData";
+    public static final String OTFI = "OTFI";
+    public static final String OTFI_CACHE_KEY_PREFIX = "OTFI-";
 
     public static final String USER_ASSERTION_EXPIRY_PROPERTY = "FlowExecution.UserAssertion.ExpiryTime";
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
@@ -63,6 +63,7 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMess
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_INVALID_FLOW_ID;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_TENANT_RESOLVE_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_UNDEFINED_FLOW_ID;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.OTFI_CACHE_KEY_PREFIX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.EMAIL_FORMAT_VALIDATOR;
 
 /**
@@ -82,14 +83,33 @@ public class FlowExecutionEngineUtils {
      */
     public static void addFlowContextToCache(FlowExecutionContext context) throws FlowEngineException {
 
+        addFlowContextToCache(context.getContextIdentifier(), context);
+    }
+
+    /**
+     * Add flow context to cache with provided key.
+     *
+     * @param cacheKeyIdentifier Cache key identifier.
+     * @param context            Flow context.
+     * @throws FlowEngineException Flow engine exception.
+     */
+    public static void addFlowContextToCache(String cacheKeyIdentifier, FlowExecutionContext context)
+            throws FlowEngineException {
+
+        if (StringUtils.isBlank(cacheKeyIdentifier)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cache key identifier is blank. Skipping adding flow context to cache.");
+            }
+            return;
+        }
         // Persist an optimized version of the context in the cache and flow context store.
         optimizeContext(context);
         FlowExecCtxCacheEntry cacheEntry = new FlowExecCtxCacheEntry(context);
-        FlowExecCtxCacheKey cacheKey = new FlowExecCtxCacheKey(context.getContextIdentifier());
+        FlowExecCtxCacheKey cacheKey = new FlowExecCtxCacheKey(cacheKeyIdentifier);
         FlowExecCtxCache.getInstance().clearCacheEntry(cacheKey);
         FlowExecCtxCache.getInstance().addToCache(cacheKey, cacheEntry);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Flow context added to cache for context id: " + context.getContextIdentifier());
+            LOG.debug("Flow context added to cache for context id: " + cacheKeyIdentifier);
         }
     }
 
@@ -136,6 +156,23 @@ public class FlowExecutionEngineUtils {
     private static void optimizeContext(FlowExecutionContext context) {
 
         context.setGraphConfig(null);
+    }
+
+    /**
+     * Build cache key for one-time flow identifier.
+     *
+     * @param otfiToken One-time flow identifier token.
+     * @return Cache key for provided token.
+     */
+    public static String buildOtfiCacheKey(String otfiToken) {
+
+        if (StringUtils.isBlank(otfiToken)) {
+            return null;
+        }
+        if (otfiToken.startsWith(OTFI_CACHE_KEY_PREFIX)) {
+            return otfiToken;
+        }
+        return OTFI_CACHE_KEY_PREFIX + otfiToken;
     }
 
     private static FlowExecutionContext populateOptimizedContext(FlowExecCtxCacheEntry entry)


### PR DESCRIPTION
## Summary
- allow the flow execution service to restore contexts via one-time flow identifiers (OTFIs)
- persist flow contexts against prefixed OTFI cache keys when executors return a token
- expose helpers for building OTFI cache keys and extend unit coverage for the new behaviour

## Testing
- mvn -pl components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine test *(fails: network unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d418d18e108326a7ef3390f3386879