### PR TITLE
Support optional flow inputs from executor responses

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
@@ -221,6 +221,7 @@ public class FlowExecutionEngine {
             finalDataDTO = new DataDTO.Builder()
                     .components(dataDTO.getComponents())
                     .requiredParams(nodeResponse.getRequiredData())
+                    .optionalParams(nodeResponse.getOptionalData())
                     .additionalData(nodeResponse.getAdditionalInfo())
                     .build();
             handleError(finalDataDTO, nodeResponse);
@@ -271,6 +272,7 @@ public class FlowExecutionEngine {
                         .url(redirectUrl)
                         .additionalData(nodeResponse.getAdditionalInfo())
                         .requiredParams(nodeResponse.getRequiredData())
+                        .optionalParams(nodeResponse.getOptionalData())
                         .build())
                 .build();
     }
@@ -293,6 +295,7 @@ public class FlowExecutionEngine {
                 .data(new DataDTO.Builder()
                         .webAuthnData(webAuthnData)
                         .requiredParams(nodeResponse.getRequiredData())
+                        .optionalParams(nodeResponse.getOptionalData())
                         .build())
                 .build();
     }
@@ -310,6 +313,7 @@ public class FlowExecutionEngine {
                 .data(new DataDTO.Builder()
                         .additionalData(nodeResponse.getAdditionalInfo())
                         .requiredParams(nodeResponse.getRequiredData())
+                        .optionalParams(nodeResponse.getOptionalData())
                         .build())
                 .build();
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
@@ -142,6 +142,7 @@ public class TaskExecutionNode implements Node {
                         .status(STATUS_INCOMPLETE)
                         .type(VIEW)
                         .requiredData(response.getRequiredData())
+                        .optionalData(response.getOptionalData())
                         .error(response.getErrorMessage())
                         .build();
             case STATUS_USER_INPUT_REQUIRED:
@@ -149,6 +150,7 @@ public class TaskExecutionNode implements Node {
                         .status(STATUS_INCOMPLETE)
                         .type(VIEW)
                         .requiredData(response.getRequiredData())
+                        .optionalData(response.getOptionalData())
                         .additionalInfo(response.getAdditionalInfo())
                         .build();
             case STATUS_CLIENT_INPUT_REQUIRED:
@@ -156,6 +158,7 @@ public class TaskExecutionNode implements Node {
                         .status(STATUS_INCOMPLETE)
                         .type(INTERNAL_PROMPT)
                         .requiredData(response.getRequiredData())
+                        .optionalData(response.getOptionalData())
                         .additionalInfo(response.getAdditionalInfo())
                         .build();
             case STATUS_WEBAUTHN:
@@ -163,6 +166,7 @@ public class TaskExecutionNode implements Node {
                         .status(STATUS_INCOMPLETE)
                         .type(WEBAUTHN)
                         .requiredData(response.getRequiredData())
+                        .optionalData(response.getOptionalData())
                         .additionalInfo(response.getAdditionalInfo())
                         .build();
             case STATUS_EXTERNAL_REDIRECTION:
@@ -170,6 +174,7 @@ public class TaskExecutionNode implements Node {
                         .status(STATUS_INCOMPLETE)
                         .type(REDIRECTION)
                         .requiredData(response.getRequiredData())
+                        .optionalData(response.getOptionalData())
                         .additionalInfo(response.getAdditionalInfo())
                         .build();
             case STATUS_USER_ERROR:
@@ -191,6 +196,7 @@ public class TaskExecutionNode implements Node {
                                               NodeConfig configs) {
 
         if ((response.getRequiredData() != null && !response.getRequiredData().isEmpty()) ||
+                (response.getOptionalData() != null && !response.getOptionalData().isEmpty()) ||
                 (response.getAdditionalInfo() != null && !response.getAdditionalInfo().isEmpty())) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Unhandled data from the executor " + executorName + " will be ignored.");

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
@@ -28,6 +28,7 @@ public class ExecutorResponse {
 
     private String result;
     private List<String> requiredData;
+    private List<String> optionalData;
     private Map<String, Object> updatedUserClaims;
     private Map<String, char[]> userCredentials;
     private Map<String, Object> contextProperties;
@@ -62,6 +63,16 @@ public class ExecutorResponse {
     public void setRequiredData(List<String> requiredData) {
 
         this.requiredData = requiredData;
+    }
+
+    public List<String> getOptionalData() {
+
+        return optionalData;
+    }
+
+    public void setOptionalData(List<String> optionalData) {
+
+        this.optionalData = optionalData;
     }
 
     public Map<String, Object> getUpdatedUserClaims() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowExecutionContext.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowExecutionContext.java
@@ -44,6 +44,7 @@ public class FlowExecutionContext implements Serializable {
     private Map<String, String> authenticatorProperties;
     private Map<String, Set<String>> currentStepInputs = new HashMap<>();
     private Map<String, Set<String>> currentRequiredInputs = new HashMap<>();
+    private Map<String, Set<String>> currentOptionalInputs = new HashMap<>();
     private List<NodeConfig> completedNodes = new ArrayList<>();
     private NodeConfig currentNode;
     private GraphConfig graphConfig;
@@ -204,6 +205,16 @@ public class FlowExecutionContext implements Serializable {
     public void setCurrentRequiredInputs(Map<String, Set<String>> currentRequiredInputs) {
 
         this.currentRequiredInputs = currentRequiredInputs;
+    }
+
+    public Map<String, Set<String>> getCurrentOptionalInputs() {
+
+        return currentOptionalInputs;
+    }
+
+    public void setCurrentOptionalInputs(Map<String, Set<String>> currentOptionalInputs) {
+
+        this.currentOptionalInputs = currentOptionalInputs;
     }
 
     public List<NodeConfig> getCompletedNodes() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/NodeResponse.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/NodeResponse.java
@@ -34,6 +34,7 @@ public class NodeResponse implements Serializable {
 
     private static final long serialVersionUID = 123456789L;
     private final List<String> requiredData;
+    private final List<String> optionalData;
     private String status;
     private String type;
     private String error;
@@ -46,6 +47,7 @@ public class NodeResponse implements Serializable {
         this.error = builder.error;
         this.requiredData = builder.requiredData;
         this.additionalInfo = builder.additionalInfo;
+        this.optionalData = builder.optionalData;
     }
 
     public String getStatus() {
@@ -61,6 +63,11 @@ public class NodeResponse implements Serializable {
     public List<String> getRequiredData() {
 
         return requiredData;
+    }
+
+    public List<String> getOptionalData() {
+
+        return optionalData;
     }
 
     public Map<String, String> getAdditionalInfo() {
@@ -107,6 +114,8 @@ public class NodeResponse implements Serializable {
         private String error;
         @JsonProperty("requiredData")
         private List<String> requiredData;
+        @JsonProperty("optionalData")
+        private List<String> optionalData;
         @JsonProperty("additionalInfo")
         private Map<String, String> additionalInfo;
 
@@ -131,6 +140,12 @@ public class NodeResponse implements Serializable {
         public Builder requiredData(List<String> requiredData) {
 
             this.requiredData = requiredData;
+            return this;
+        }
+
+        public Builder optionalData(List<String> optionalData) {
+
+            this.optionalData = optionalData;
             return this;
         }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -186,6 +186,7 @@ public class InputValidationService {
         // Clear the current step inputs and required inputs.
         context.getCurrentStepInputs().clear();
         context.getCurrentRequiredInputs().clear();
+        context.getCurrentOptionalInputs().clear();
 
         if (dataDTO.getComponents() != null) {
             for (ComponentDTO component : dataDTO.getComponents()) {
@@ -243,6 +244,8 @@ public class InputValidationService {
                 context.getCurrentStepInputs().isEmpty()) {
             handleRequiredInputs(dataDTO, context);
         }
+
+        handleOptionalInputs(dataDTO, context);
     }
 
     /**
@@ -255,6 +258,30 @@ public class InputValidationService {
 
         context.getCurrentRequiredInputs().put(DEFAULT_ACTION, new HashSet<>(dataDTO.getRequiredParams()));
         context.getCurrentStepInputs().put(DEFAULT_ACTION, new HashSet<>(dataDTO.getRequiredParams()));
+    }
+
+    /**
+     * Handle optional inputs by adding them to the current step inputs in the context.
+     *
+     * @param dataDTO Data transfer object containing components and optional parameters.
+     * @param context Flow context.
+     */
+    private static void handleOptionalInputs(DataDTO dataDTO, FlowExecutionContext context) {
+
+        if (dataDTO.getOptionalParams() == null || dataDTO.getOptionalParams().isEmpty()) {
+            return;
+        }
+
+        if (context.getCurrentStepInputs().isEmpty()) {
+            context.getCurrentStepInputs().put(DEFAULT_ACTION, new HashSet<>());
+        }
+
+        for (Map.Entry<String, Set<String>> entry : context.getCurrentStepInputs().entrySet()) {
+            entry.getValue().addAll(dataDTO.getOptionalParams());
+            context.getCurrentOptionalInputs()
+                    .computeIfAbsent(entry.getKey(), key -> new HashSet<>())
+                    .addAll(dataDTO.getOptionalParams());
+        }
     }
 
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -155,11 +155,15 @@ public class InputValidationServiceTest {
         FlowExecutionContext.setGraphConfig(defaultGraph);
         DataDTO dataDTO = new DataDTO.Builder()
                 .requiredParams(Collections.singletonList("input1"))
+                .optionalParams(Collections.singletonList("input2"))
                 .build();
         inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
         Assert.assertEquals(FlowExecutionContext.getCurrentStepInputs().size(), 1);
-        Assert.assertEquals(FlowExecutionContext.getCurrentStepInputs().get(DEFAULT_ACTION).size(), 1);
+        Assert.assertEquals(FlowExecutionContext.getCurrentStepInputs().get(DEFAULT_ACTION).size(), 2);
         Assert.assertTrue(FlowExecutionContext.getCurrentStepInputs().get(DEFAULT_ACTION).contains("input1"));
+        Assert.assertTrue(FlowExecutionContext.getCurrentStepInputs().get(DEFAULT_ACTION).contains("input2"));
+        Assert.assertEquals(FlowExecutionContext.getCurrentOptionalInputs().get(DEFAULT_ACTION).size(), 1);
+        Assert.assertTrue(FlowExecutionContext.getCurrentOptionalInputs().get(DEFAULT_ACTION).contains("input2"));
     }
 
     @Test
@@ -177,6 +181,28 @@ public class InputValidationServiceTest {
         Assert.assertEquals(FlowExecutionContext.getFlowUser().getClaims().get(CLAIM_URI_PREFIX + "input1"),
                 "value1");
         Assert.assertEquals(FlowExecutionContext.getUserInputData().get("input2"), "value2");
+    }
+
+    @Test
+    public void testOptionalInputsAllowed() throws FlowEngineException {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+        DataDTO dataDTO = new DataDTO.Builder()
+                .requiredParams(Collections.singletonList("input1"))
+                .optionalParams(Collections.singletonList("input2"))
+                .build();
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        Map<String, String> userInputData = new HashMap<>();
+        userInputData.put("input1", "value1");
+        userInputData.put("input2", "value2");
+        FlowExecutionContext.getUserInputData().putAll(userInputData);
+        FlowExecutionContext.setCurrentActionId(DEFAULT_ACTION);
+
+        inputValidationService.validateInputs(FlowExecutionContext);
+        Assert.assertEquals(FlowExecutionContext.getCurrentOptionalInputs().get(DEFAULT_ACTION).size(), 1);
+        Assert.assertTrue(FlowExecutionContext.getCurrentOptionalInputs().get(DEFAULT_ACTION).contains("input2"));
     }
 
     private FlowExecutionContext initiateFlowContext() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/DataDTO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/DataDTO.java
@@ -33,6 +33,7 @@ public class DataDTO implements Serializable {
     private String redirectURL;
     private List<ComponentDTO> components;
     private List<String> requiredParams;
+    private List<String> optionalParams;
     private Map<String, String> additionalData;
     private Map<String, Object> webAuthnData;
 
@@ -46,6 +47,7 @@ public class DataDTO implements Serializable {
         this.action = builder.action;
         this.redirectURL = builder.redirectURL;
         this.requiredParams = builder.requiredParams;
+        this.optionalParams = builder.optionalParams;
         this.additionalData = builder.additionalData;
         this.webAuthnData = builder.webAuthnData;
     }
@@ -88,6 +90,11 @@ public class DataDTO implements Serializable {
         return requiredParams;
     }
 
+    public List<String> getOptionalParams() {
+
+        return optionalParams;
+    }
+
     public Map<String, String> getAdditionalData() {
 
         return additionalData;
@@ -109,6 +116,14 @@ public class DataDTO implements Serializable {
         this.requiredParams.add(param);
     }
 
+    public void addOptionalParam(String param) {
+
+        if (this.optionalParams == null) {
+            this.optionalParams = new ArrayList<>();
+        }
+        this.optionalParams.add(param);
+    }
+
     public Map<String, Object> getWebAuthnData() {
 
         return webAuthnData;
@@ -123,6 +138,7 @@ public class DataDTO implements Serializable {
         private ActionDTO action;
         private String redirectURL;
         private List<String> requiredParams;
+        private List<String> optionalParams;
         private Map<String, String> additionalData;
         private Map<String, Object> webAuthnData;
 
@@ -147,6 +163,12 @@ public class DataDTO implements Serializable {
         public Builder requiredParams(List<String> requiredParams) {
 
             this.requiredParams = requiredParams;
+            return this;
+        }
+
+        public Builder optionalParams(List<String> optionalParams) {
+
+            this.optionalParams = optionalParams;
             return this;
         }
 


### PR DESCRIPTION
## Summary
- allow executor and node responses to expose optional input data alongside required data
- propagate optional parameters through the flow execution engine and DTO layer to reach input validation
- update the input validation service to treat optional inputs as valid and add coverage for the new behaviour

## Testing
- mvn -pl components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine -am test -Dtest=InputValidationServiceTest *(fails: Non-resolvable parent POM due to forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_68e765e70d088326ae95de6f5e585d30