### PR TITLE
Refactor flow engine executor context preparation

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/AuthenticationExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/AuthenticationExecutor.java
@@ -18,11 +18,10 @@
 
 package org.wso2.carbon.identity.flow.execution.engine.graph;
 
-import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.Property;
-import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServerException;
+import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
@@ -48,21 +47,21 @@ public abstract class AuthenticationExecutor implements Executor {
     public abstract String getAMRValue();
 
     /**
-     * Add Identity Provider configurations to the flow execution context.
+     * Resolves Identity Provider configurations and populates authenticator properties in the context.
+     * Executors that do not require an IDP (i.e. no {@code idpName} in metadata) are unaffected.
      *
-     * @param context      Flow execution context.
-     * @param executorDTO  Executor data transfer object containing metadata.
-     * @throws FlowEngineServerException If an error occurs while retrieving the Identity Provider configuration.
+     * @param context     Flow execution context.
+     * @param executorDTO Executor configuration and metadata.
+     * @throws FlowEngineException If an error occurs while retrieving the Identity Provider configuration.
      */
-    public void addIdpConfigsToContext(FlowExecutionContext context, ExecutorDTO executorDTO)
-            throws FlowEngineServerException {
+    @Override
+    public void prepareContext(FlowExecutionContext context, ExecutorDTO executorDTO) throws FlowEngineException {
 
-        String tenantDomain = context.getTenantDomain();
-        Map<String, String> propertyMap = new HashMap<>();
         Map<String, String> metadata = executorDTO.getMetadata();
         if (metadata == null || !metadata.containsKey(IDP_NAME)) {
             return;
         }
+        String tenantDomain = context.getTenantDomain();
         String idpName = metadata.get(IDP_NAME);
         try {
             IdentityProvider idp =
@@ -72,11 +71,11 @@ public abstract class AuthenticationExecutor implements Executor {
                         tenantDomain);
             }
             FederatedAuthenticatorConfig authenticatorConfig = idp.getDefaultAuthenticatorConfig();
+            Map<String, String> propertyMap = new HashMap<>();
             for (Property property : authenticatorConfig.getProperties()) {
                 propertyMap.put(property.getName(), property.getValue());
             }
             context.setAuthenticatorProperties(propertyMap);
-            context.setExternalIdPConfig(new ExternalIdPConfig(idp));
         } catch (IdentityProviderManagementException e) {
             throw handleServerException(context.getFlowType(), ERROR_CODE_GET_IDP_CONFIG_FAILURE, e, idpName,
                     tenantDomain);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/Executor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/Executor.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.flow.execution.engine.graph;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
 
 import java.util.List;
 
@@ -35,6 +36,19 @@ public interface Executor {
      * @return Name of the executor.
      */
     String getName();
+
+    /**
+     * Prepare the flow execution context before executor invocation.
+     * Default implementation is a no-op. Executors that require context
+     * setup (e.g. resolving IDP configurations) should override this method.
+     *
+     * @param context     Flow execution context.
+     * @param executorDTO Executor configuration and metadata.
+     * @throws FlowEngineException If an error occurs during context preparation.
+     */
+    default void prepareContext(FlowExecutionContext context, ExecutorDTO executorDTO) throws FlowEngineException {
+
+    }
 
     /**
      * Execute the logic of the executor.

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
@@ -110,10 +110,7 @@ public class TaskExecutionNode implements Node {
         Executor mappedFlowExecutor = resolveExecutor(context.getFlowType(), configs, context.getGraphConfig().getId(),
                 context.getTenantDomain());
 
-        if (mappedFlowExecutor instanceof AuthenticationExecutor) {
-            ((AuthenticationExecutor) mappedFlowExecutor).addIdpConfigsToContext(context, configs.getExecutorConfig());
-        }
-
+        mappedFlowExecutor.prepareContext(context, configs.getExecutorConfig());
         ExecutorResponse response = mappedFlowExecutor.execute(context);
         if (response == null) {
             throw handleServerException(context.getFlowType(), ERROR_CODE_EXECUTOR_FAILURE,

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowExecutionContext.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowExecutionContext.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.flow.execution.engine.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.slf4j.MDC;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.flow.mgt.model.GraphConfig;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 
@@ -56,8 +55,6 @@ public class FlowExecutionContext implements Serializable {
     private String portalUrl;
     private String applicationId;
     private String flowType;
-    @JsonIgnore
-    private ExternalIdPConfig externalIdPConfig;
     private boolean generateAuthenticationAssertion = false;
 
     public NodeConfig getCurrentNode() {
@@ -173,17 +170,6 @@ public class FlowExecutionContext implements Serializable {
     public void setAuthenticatorProperties(Map<String, String> authenticatorProperties) {
 
         this.authenticatorProperties = authenticatorProperties;
-    }
-
-    public ExternalIdPConfig getExternalIdPConfig() {
-
-        return externalIdPConfig;
-    }
-
-    public void setExternalIdPConfig(
-            ExternalIdPConfig externalIdPConfig) {
-
-        this.externalIdPConfig = externalIdPConfig;
     }
 
     public Map<String, Set<String>> getCurrentStepInputs() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNodeTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNodeTest.java
@@ -378,7 +378,6 @@ public class TaskExecutionNodeTest {
             when(idpManager.getIdPByName("validIdp", TENANT_DOMAIN)).thenReturn(idp);
 
             taskExecutionNode.execute(context, nodeConfig);
-            assertNotNull(context.getExternalIdPConfig());
             assertNotNull(context.getAuthenticatorProperties());
             assertEquals(context.getAuthenticatorProperties().size(), 1);
             assertEquals(context.getAuthenticatorProperties().get("property1"), "value1");
@@ -433,7 +432,7 @@ public class TaskExecutionNodeTest {
 
         when(executor.execute(any())).thenReturn(executorResponse);
         when(executor.getName()).thenReturn(TEST_EXECUTOR);
-        doCallRealMethod().when(executor).addIdpConfigsToContext(any(), any());
+        doCallRealMethod().when(executor).prepareContext(any(), any());
 
         MockedStatic<FlowExecutionEngineDataHolder> mocked = mockStatic(FlowExecutionEngineDataHolder.class);
         FlowExecutionEngineDataHolder dataHolder = mock(FlowExecutionEngineDataHolder.class);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/ExecutorDTO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/ExecutorDTO.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.flow.mgt.model;
 
+import org.wso2.carbon.identity.flow.mgt.Constants;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -85,7 +87,7 @@ public class ExecutorDTO implements Serializable {
         if (metadata == null) {
             metadata = new HashMap<>();
         }
-        metadata.put("idpName", idpName);
+        metadata.put(Constants.IDP_NAME, idpName);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `prepareContext(context, executorDTO)` as a default no-op lifecycle method on the `Executor` interface, allowing any executor to perform pre-execution context setup without requiring type checks at the call site.
- Remove the `instanceof AuthenticationExecutor` branch in `TaskExecutionNode` — all executors now go through the same uniform `prepareContext` call.
- Rename `addIdpConfigsToContext` in `AuthenticationExecutor` to `prepareContext` (`@Override`), dropping the `ExternalIdPConfig` population since nothing in the engine consumed that field.
- Remove `externalIdPConfig` field, getter, and setter from `FlowExecutionContext`, eliminating the coupling to the authentication-framework `ExternalIdPConfig` model.
- Fix `ExecutorDTO.setIdpName()` to use `Constants.IDP_NAME` instead of a hardcoded `"idpName"` string literal.

## Motivation

The previous design had two structural issues:
1. `TaskExecutionNode` performed an `instanceof` check against a concrete subtype (`AuthenticationExecutor`) to call a pre-execution hook — violating OCP and making it impossible to add similar hooks in other executor types without modifying the node.
2. `FlowExecutionContext` held an `ExternalIdPConfig` object (from the authentication-framework) that was `@JsonIgnore`d (not serialized), never read by any executor, and introduced an unwanted layer dependency from the flow engine into the authentication framework.

## Test plan

- [ ] Existing `TaskExecutionNodeTest` passes — IDP config retrieval, null IDP, and management exception cases all covered.
- [ ] Non-authentication executors are unaffected (default no-op `prepareContext`).
- [ ] Authentication executors with no `idpName` metadata are unaffected (early return in `prepareContext`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)